### PR TITLE
Fix loadKey conflict.

### DIFF
--- a/base/base.go
+++ b/base/base.go
@@ -63,6 +63,17 @@ func InitServices(configPath string) error {
 		return nil
 	}
 	eventService = event
+	d, err := time.ParseDuration(serverConfig.LoadKey.RawRetryInterval)
+	if err != nil {
+		return err
+	}
+	serverConfig.LoadKey.retryInterval = d
+
+	d, err = time.ParseDuration(serverConfig.LoadKey.RawLoadTimeout)
+	if err != nil {
+		return err
+	}
+	serverConfig.LoadKey.loadTimeout = d
 	return nil
 }
 

--- a/cmd/config.template.yaml
+++ b/cmd/config.template.yaml
@@ -42,6 +42,10 @@ event_service:
     worker_process_interval: 1m
     worker_drain_duration: 5s
 
+load_key:
+  retry_times: 5
+  retry_interval: "2ms"
+  load_timeout: "100ms"
     
 # 用于同步数据的后端数据库
 db_cluster:

--- a/service/load.go
+++ b/service/load.go
@@ -45,7 +45,7 @@ func loadKey(key string) error {
 	metric := base.GetMetricService()
 	var loadErr error
 	for i := 0; i < loadRetryTimes; i++ {
-		needLoaded, err := isKeyNeedLoaded(key)
+		needLoaded, err := isKeyNeedLoad(key)
 		if err != nil {
 			return err
 		}

--- a/service/load_test.go
+++ b/service/load_test.go
@@ -466,7 +466,7 @@ func TestIsKeyNeedLoaded(t *testing.T) {
 	metaKey := getMetaKey(key)
 	// both key and meta key do not exist
 	testEmptyKeysInRedis(key, metaKey)
-	needLoaded, err := isKeyNeedLoaded(key)
+	needLoaded, err := isKeyNeedLoad(key)
 	assert.True(t, needLoaded)
 	assert.Nil(t, err)
 	testEmptyKeysInRedis(key, metaKey)
@@ -474,7 +474,7 @@ func TestIsKeyNeedLoaded(t *testing.T) {
 	// key exists, meta key does not exist
 	testEmptyKeysInRedis(key, metaKey)
 	client.Set(testContextTODO, key, "value", 0)
-	needLoaded, err = isKeyNeedLoaded(key)
+	needLoaded, err = isKeyNeedLoad(key)
 	assert.False(t, needLoaded)
 	assert.Nil(t, err)
 	testEmptyKeysInRedis(key, metaKey)
@@ -482,7 +482,7 @@ func TestIsKeyNeedLoaded(t *testing.T) {
 	// key does not exist, meta key exists
 	testEmptyKeysInRedis(key, metaKey)
 	client.HSet(testContextTODO, metaKey, "loaded", "1")
-	needLoaded, err = isKeyNeedLoaded(key)
+	needLoaded, err = isKeyNeedLoad(key)
 	assert.False(t, needLoaded)
 	assert.Nil(t, err)
 	testEmptyKeysInRedis(key, metaKey)
@@ -491,7 +491,7 @@ func TestIsKeyNeedLoaded(t *testing.T) {
 	testEmptyKeysInRedis(key, metaKey)
 	client.Set(testContextTODO, key, "value", 0)
 	client.HSet(testContextTODO, metaKey, "loaded", "1")
-	needLoaded, err = isKeyNeedLoaded(key)
+	needLoaded, err = isKeyNeedLoad(key)
 	assert.False(t, needLoaded)
 	assert.Nil(t, err)
 	testEmptyKeysInRedis(key, metaKey)
@@ -499,7 +499,7 @@ func TestIsKeyNeedLoaded(t *testing.T) {
 	// metaKey exist, but loaded filed not exist
 	testEmptyKeysInRedis(key, metaKey)
 	client.HSet(testContextTODO, metaKey, "loaded_test", "1")
-	needLoaded, err = isKeyNeedLoaded(key)
+	needLoaded, err = isKeyNeedLoad(key)
 	assert.True(t, needLoaded)
 	assert.Nil(t, err)
 	testEmptyKeysInRedis(key, metaKey)
@@ -507,7 +507,7 @@ func TestIsKeyNeedLoaded(t *testing.T) {
 	// metaKey exist, but loaded filed != "1"
 	testEmptyKeysInRedis(key, metaKey)
 	client.HSet(testContextTODO, metaKey, "loaded", "2")
-	needLoaded, err = isKeyNeedLoaded(key)
+	needLoaded, err = isKeyNeedLoad(key)
 	assert.True(t, needLoaded)
 	assert.Nil(t, err)
 	testEmptyKeysInRedis(key, metaKey)

--- a/service/server.go
+++ b/service/server.go
@@ -301,7 +301,7 @@ func iskeyValid(key string) bool {
 	return (leftBraceIndex != -1) && (rightBraceIndex != -1) && (leftBraceIndex < rightBraceIndex)
 }
 
-func isKeyNeedLoaded(key string) (bool, error) {
+func isKeyNeedLoad(key string) (bool, error) {
 	redisClient := base.GetRedisCluster()
 	commands, err := redisClient.Pipelined(
 		context.TODO(),

--- a/service/server.go
+++ b/service/server.go
@@ -220,22 +220,10 @@ func preProcessCommand(command commands.Commander) error {
 	return nil
 }
 
-// 1. check if key exists: if key exists, return else go to step 2
-// 2. check if key needs loaded: if not needs, return, else go to step 3
-// 3. load key from database
 func preProcessKey(key string) error {
 	// if !iskeyValid(key) {
 	// 	return newInvalidKeyError(key)
 	// }
-
-	needLoaded, err := isKeyNeedLoaded(key)
-	if err != nil {
-		return err
-	}
-	if !needLoaded {
-		return nil
-	}
-
 	if err := loadKey(key); err != nil {
 		return newLoadError(err)
 	}


### PR DESCRIPTION
修改从数据库加载 key 的逻辑：

1、并发加载同一个 key 时，每个服务实例只允许一个请求与数据库交互，其它请求等待其加载完成再返回（之前其它请求直接返回加载冲突错误）
2、加载 key 失败后，如果是可重试错误，则可以重试